### PR TITLE
[BUG] Https written twice

### DIFF
--- a/content/pages/cv.html
+++ b/content/pages/cv.html
@@ -62,7 +62,7 @@
         <details open>
           <summary>
             <time datetime="2021-05">April 2023</time>–present
-            Tech lead at <a href="https://https://www.carbonequity.com/">Carbon Equity</a>
+            Tech lead at <a href="https://www.carbonequity.com/">Carbon Equity</a>
           </summary>
           <ul>
             <li>


### PR DESCRIPTION
### Summary
On your work section, present, the carbon equity link has two sets of `https://`

### Where
https://github.com/knyghty/carrick.eu/blob/main/content/pages/cv.html#L65C91-L65C91

Fixed it :)